### PR TITLE
Fixes resource mapping for .NET Core

### DIFF
--- a/Novell.Directory.LDAP/Utilclass/ResourcesHandler.cs
+++ b/Novell.Directory.LDAP/Utilclass/ResourcesHandler.cs
@@ -181,7 +181,7 @@ namespace Novell.Directory.Ldap.Utilclass
 			{
 /*
 				defaultResultCodes = ResourceManager.CreateFileBasedResourceManager("ResultCodeMessages", "Resources", null);*/
-				defaultResultCodes = new ResourceManager("ResultCodeMessages", typeof(ResourcesHandler).GetTypeInfo().Assembly);
+				defaultResultCodes = new ResourceManager("Novell.Directory.LDAP.Properties.ResultCodeMessages", typeof(ResultCodeMessages).GetTypeInfo().Assembly);
 			}
 
 			if (defaultLocale == null)


### PR DESCRIPTION
The .NET Core error messages from the resources file would crash, could not map correctly.