### PR TITLE
Adjust namespace used to load ResourceManager to match what end rest is when library is published

### DIFF
--- a/Novell.Directory.LDAP/Utilclass/ResourcesHandler.cs
+++ b/Novell.Directory.LDAP/Utilclass/ResourcesHandler.cs
@@ -181,7 +181,7 @@ namespace Novell.Directory.Ldap.Utilclass
 			{
 /*
 				defaultResultCodes = ResourceManager.CreateFileBasedResourceManager("ResultCodeMessages", "Resources", null);*/
-				defaultResultCodes = new ResourceManager("Novell.Directory.LDAP.Properties.ResultCodeMessages", typeof(ResultCodeMessages).GetTypeInfo().Assembly);
+				defaultResultCodes = new ResourceManager("Novell.Directory.LDAP.VQ.Properties.ResultCodeMessages", typeof(ResultCodeMessages).GetTypeInfo().Assembly);
 			}
 
 			if (defaultLocale == null)


### PR DESCRIPTION
When an error occurs currently it results in:

```
Exception(Type:MissingManifestResourceException):Could not find any resources appropriate for the specified culture or the neutral culture. Make sure "Novell.Directory.LDAP.Properties.ResultCodeMessages.resources" was correctly embedded or linked into assembly "Novell.Directory.LDAP.VQ" at compile time, or that all the satellite assemblies required are loadable and fully signed.
```

As this project embeds resources in the properties folder and it has a title of `Novell.Directory.LDAP.VQ` it appears dotnetcore is rewriting namespaces to match that so when loading up resources via namespace it has to match that of the assembly/project title.