### PR TITLE
Replaced Dns.GetHostEntryAsync with IPAddress.Parse 

### DIFF
--- a/Novell.Directory.LDAP/Connection.cs
+++ b/Novell.Directory.LDAP/Connection.cs
@@ -687,9 +687,8 @@ namespace Novell.Directory.Ldap
                             this.host = host;
                             this.port = port;
                             sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
-                            IPAddress hostadd = Dns.GetHostEntryAsync(host)
+                            IPAddress hostadd = Dns.GetHostAddressesAsync(host)
                                                    .Result
-                                                   .AddressList
                                                    .FirstOrDefault(address => address.AddressFamily == AddressFamily.InterNetwork);
 
                             IPEndPoint ephost = new IPEndPoint(hostadd, port);


### PR DESCRIPTION
On netcore1.1 there is a bug with `Dns.GetHostEntry` so replaced logic to get the IPAddress